### PR TITLE
Fix input variable reference in entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-echo "${GCLOUD_AUTH}" | base64 -d > "${HOME}/gcloud.json" 
+echo "${INPUT_ACCOUNT_KEY}" | base64 -d > "${HOME}/gcloud.json" 
 gcloud auth activate-service-account --key-file="${HOME}/gcloud.json"
 
 echo "::set-output name=username::oauth2accesstoken"


### PR DESCRIPTION
The documented mandatory input variable `account_key` is not referenced in the `entrypoint.sh`. This causes the action to fail with the following error:
```
ERROR: (gcloud.auth.activate-service-account) Could not read json file /github/home/gcloud.json: No JSON object could be decoded
```
After referencing the proper variable it works as expected.