### PR TITLE
Fix #6: Separate test logic out of the main Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,3 @@
-FROM gcr.io/cloud-builders/gcloud-slim as runtime
+FROM gcr.io/cloud-builders/gcloud-slim
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
-
-FROM runtime as test
-RUN add-apt-repository ppa:duggan/bats \
-    && apt-get update \
-    && apt-get install -y bats
-ADD test.bats /test.bats
-ADD mock.sh /builder/google-cloud-sdk/bin/gcloud
-RUN /test.bats
-
-FROM runtime

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,13 @@
+FROM gcr.io/cloud-builders/gcloud-slim as runtime
+ADD entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+FROM runtime as test
+RUN add-apt-repository ppa:duggan/bats \
+    && apt-get update \
+    && apt-get install -y bats
+ADD test.bats /test.bats
+ADD mock.sh /builder/google-cloud-sdk/bin/gcloud
+RUN /test.bats
+
+FROM runtime


### PR DESCRIPTION
I've tested and confirmed this will now run on the latest `gcr.io/cloud-builders/gcloud-slim`

Tested with this Marketplace Action: https://github.com/marketplace/actions/gcloud-container-registry-docker-login-krashleviathan-fork on a different private repository of mine.

I just had to change the name in `action.yml` slightly, since the action name has to be unique. Once this gets merged, I can remove my fork's marketplace action.