### PR TITLE
Fix: update readme file due to the latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ jobs:
       uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: myDocker/repository
-        username: ${{ steps.gcloud.outputs.username }}
-        password: ${{ steps.gcloud.outputs.password }}
+        username: ${{ env.username }}
+        password: ${{ env.password }}
         registry: gcr.io, us.gcr.io, eu.gcr.io or asia.gcr.io
 ```
 


### PR DESCRIPTION
Variables `username` and `password` are no longer accessible via `steps.gcloud.outputs` after the [latest release](https://github.com/elgohr/gcloud-login-action/releases/tag/v2). For retrieving values you have to use `env`

<img width="477" alt="image" src="https://user-images.githubusercontent.com/4931117/228852315-6dedc267-16fe-4633-ae20-812882dfd35e.png">

![image](https://user-images.githubusercontent.com/4931117/228854120-e8b0aae8-a9c6-4f6e-b66c-89ca131a93d8.png)
